### PR TITLE
Modify name for the repo to resolve TCPDF dependency issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "tecnick.com/tcpdf",
+	"name": "tecnickcom/tcpdf",
 	"version": "6.2.14",
 	"homepage": "http://www.tcpdf.org/",
 	"type": "library",


### PR DESCRIPTION
This repo should be an alternative to `tecnickcom/tcpdf` to resolve the dependency of `setasign/fpdi-tcpdf`, so I change the package name.

Some project I'm maintaining depends on `onigoetz/fpdi_tcpdf`, but, unfortunately, it's been deprecated. I should migrate to `setasign/fpdi-tcpdf`, the successor, but it no longer depends on `tecnick.com/tcpdf` but `tecnickcom/tcpdf` because `tecnick.com/tcpdf` has been deprecated as well. I need to set the repo as the private repo for composer.